### PR TITLE
adding `generate-react-cli` to aid in component file generation

### DIFF
--- a/generate-react-cli.json
+++ b/generate-react-cli.json
@@ -1,0 +1,18 @@
+{
+  "usesTypeScript": false,
+  "usesCssModule": false,
+  "cssPreprocessor": "scss",
+  "testLibrary": "Enzyme",
+  "component": {
+    "default": {
+      "customTemplates": {
+        "component": "generate-react-cli/templates/component/component.js"
+      },
+      "path": "src/components",
+      "withStyle": true,
+      "withTest": true,
+      "withStory": true,
+      "withLazy": false
+    }
+  }
+}

--- a/generate-react-cli/templates/component/component.js
+++ b/generate-react-cli/templates/component/component.js
@@ -1,0 +1,10 @@
+import React from "react";
+import "./TemplateName.scss";
+
+const TemplateName = () => (
+  <div className="TemplateName">
+    <h1>TemplateName component</h1>
+  </div>
+);
+
+export default TemplateName;


### PR DESCRIPTION
[generate-react-cli](https://www.npmjs.com/package/generate-react-cli) is a cli to avoid generating component files manually, as manually created boilerplate gets cumbersome and is prone to errors.

Look at the files committed in this pull request in order to see that a config and a template file were added to the project for that purpose.

It is just a matter of running the command `npx generate-react-cli component [YourComponentName]`
