### PR TITLE
Adding items to the cart state

### DIFF
--- a/src/components/CollectionItem/CollectionItem.scss
+++ b/src/components/CollectionItem/CollectionItem.scss
@@ -4,6 +4,7 @@
   flex-direction: column;
   height: 350px;
   align-items: center;
+  position: relative;
 
   .image {
     width: 100%;
@@ -27,6 +28,24 @@
 
     .price {
       width: 10%;
+    }
+  }
+
+  .CustomButton {
+    width: 80%;
+    opacity: 0.7;
+    position: absolute;
+    top: 255px;
+    display: none;
+  }
+
+  &:hover {
+    .image {
+      opacity: 0.8;
+    }
+    .CustomButton {
+      display: block;
+      opacity: 0.85;
     }
   }
 }

--- a/src/components/CollectionItem/index.jsx
+++ b/src/components/CollectionItem/index.jsx
@@ -1,10 +1,15 @@
 import React from "react";
+import { connect } from "react-redux";
+
+import { addItem } from "../../redux/cart/actions";
 
 import CustomButton from "../CustomButton";
 
 import "./CollectionItem.scss";
 
-function CollectionItem({ id, name, price, imageUrl }) {
+function CollectionItem({ item, addItem }) {
+  const { name, price, imageUrl } = item;
+
   return (
     <div className="CollectionItem">
       <div className="image" style={{ backgroundImage: `url(${imageUrl})` }} />
@@ -12,9 +17,15 @@ function CollectionItem({ id, name, price, imageUrl }) {
         <span className="name">{name}</span>
         <span className="price">{price}</span>
       </div>
-      <CustomButton inverted>Add to Cart</CustomButton>
+      <CustomButton inverted onClick={() => addItem(item)}>
+        Add to Cart
+      </CustomButton>
     </div>
   );
 }
 
-export default CollectionItem;
+const mapDispatchToProps = (dispatch) => ({
+  addItem: (item) => dispatch(addItem(item)),
+});
+
+export default connect(null, mapDispatchToProps)(CollectionItem);

--- a/src/components/CollectionItem/index.jsx
+++ b/src/components/CollectionItem/index.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import CustomButton from "../CustomButton";
+
 import "./CollectionItem.scss";
 
 function CollectionItem({ id, name, price, imageUrl }) {
@@ -10,6 +12,7 @@ function CollectionItem({ id, name, price, imageUrl }) {
         <span className="name">{name}</span>
         <span className="price">{price}</span>
       </div>
+      <CustomButton inverted>Add to Cart</CustomButton>
     </div>
   );
 }

--- a/src/components/CollectionPreview/index.jsx
+++ b/src/components/CollectionPreview/index.jsx
@@ -9,8 +9,8 @@ function CollectionPreview({ title, items }) {
       <div className="preview">
         {items
           .filter((item, i) => i < 4)
-          .map(({ id, ...otherItemProps }) => (
-            <CollectionItem key={id} {...otherItemProps} />
+          .map((item) => (
+            <CollectionItem key={item.id} item={item} />
           ))}
       </div>
     </div>

--- a/src/components/CustomButton/CustomButton.scss
+++ b/src/components/CustomButton/CustomButton.scss
@@ -29,4 +29,16 @@
       border: none;
     }
   }
+
+  &.inverted {
+    background-color: white;
+    color: black;
+    border: 1px solid black;
+
+    &:hover {
+      background-color: black;
+      color: white;
+      border: none;
+    }
+  }
 }

--- a/src/components/CustomButton/index.jsx
+++ b/src/components/CustomButton/index.jsx
@@ -2,9 +2,16 @@ import React from "react";
 
 import "./CustomButton.scss";
 
-const CustomButton = ({ children, isGoogleSignIn, ...otherProps }) => (
+const CustomButton = ({
+  children,
+  isGoogleSignIn,
+  inverted,
+  ...otherProps
+}) => (
   <button
-    className={`${isGoogleSignIn ? "google-sign-in" : ""} CustomButton`}
+    className={`${inverted ? "inverted" : ""} ${
+      isGoogleSignIn ? "google-sign-in" : ""
+    } CustomButton`}
     {...otherProps}
   >
     {children}

--- a/src/redux/cart/actions.js
+++ b/src/redux/cart/actions.js
@@ -3,3 +3,8 @@ import { CartActionTypes } from "./types";
 export const toggleCartHidden = () => ({
   type: CartActionTypes.TOGGLE_CART_HIDDEN,
 });
+
+export const addItem = (item) => ({
+  type: CartActionTypes.ADD_ITEM,
+  payload: item,
+});

--- a/src/redux/cart/reducer.js
+++ b/src/redux/cart/reducer.js
@@ -1,7 +1,9 @@
 import { CartActionTypes } from "./types";
+import { addItemToCart } from "./utils";
 
 const INITIAL_STATE = {
   hidden: true,
+  cartItems: [],
 };
 
 const cartReducer = (state = INITIAL_STATE, action) => {
@@ -10,6 +12,11 @@ const cartReducer = (state = INITIAL_STATE, action) => {
       return {
         ...state,
         hidden: !state.hidden,
+      };
+    case CartActionTypes.ADD_ITEM:
+      return {
+        ...state,
+        cartItems: addItemToCart(state.cartItems, action.payload),
       };
 
     default:

--- a/src/redux/cart/types.js
+++ b/src/redux/cart/types.js
@@ -1,3 +1,4 @@
 export const CartActionTypes = {
   TOGGLE_CART_HIDDEN: "TOGGLE_CART_HIDDEN",
+  ADD_ITEM: "ADD_ITEM",
 };

--- a/src/redux/cart/utils.js
+++ b/src/redux/cart/utils.js
@@ -1,0 +1,14 @@
+export const addItemToCart = (cartItems, cartItemToAdd) => {
+  const existingCartItem = cartItems.find(
+    (cartItem) => cartItem.id === cartItemToAdd.id
+  );
+
+  if (existingCartItem) {
+    return cartItems.map((cartItem) =>
+      cartItem.id === cartItemToAdd.id
+        ? { ...cartItem, quantity: cartItem.quantity + 1 }
+        : cartItem
+    );
+  }
+  return [...cartItems, { ...cartItemToAdd, quantity: 1 }];
+};


### PR DESCRIPTION
- A new `inverted` variant has been added to the `CustomButton` component
- It has been used as a new 'Add to Cart' button in the `CollectionItem` component
- Now, by pressing this new button from any item in any collection preview section (in the '/shop' route), items can now be added to the Redux `state.cart`, grouped by `item.id`