### PR TITLE
CartItem components in CartDropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12229,6 +12229,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
     "resolve": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3",
     "redux": "^4.0.5",
-    "redux-logger": "^3.0.6"
+    "redux-logger": "^3.0.6",
+    "reselect": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/CartDropdown/CartDropdown.jsx
+++ b/src/components/CartDropdown/CartDropdown.jsx
@@ -1,16 +1,24 @@
 import React from "react";
+import { connect } from "react-redux";
 
+import CartItem from "../CartItem/CartItem";
 import CustomButton from "../CustomButton";
 
 import "./CartDropdown.scss";
 
-const CartDropdown = () => {
+const CartDropdown = ({ cartItems }) => {
   return (
     <div className="CartDropdown">
-      <div className="items" />
+      <div className="items">
+        {cartItems.map((item) => (
+          <CartItem key={item.id} item={item} />
+        ))}
+      </div>
       <CustomButton>Go to checkout</CustomButton>
     </div>
   );
 };
 
-export default CartDropdown;
+const mapStateToProps = ({ cart: { cartItems } }) => ({ cartItems });
+
+export default connect(mapStateToProps)(CartDropdown);

--- a/src/components/CartDropdown/CartDropdown.jsx
+++ b/src/components/CartDropdown/CartDropdown.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
+import { selectCartItems } from "../../redux/cart/selectors";
 
 import CartItem from "../CartItem/CartItem";
 import CustomButton from "../CustomButton";
@@ -19,6 +20,6 @@ const CartDropdown = ({ cartItems }) => {
   );
 };
 
-const mapStateToProps = ({ cart: { cartItems } }) => ({ cartItems });
+const mapStateToProps = (state) => ({ cartItems: selectCartItems(state) });
 
 export default connect(mapStateToProps)(CartDropdown);

--- a/src/components/CartDropdown/CartDropdown.scss
+++ b/src/components/CartDropdown/CartDropdown.scss
@@ -11,11 +11,11 @@
   right: 40px;
   z-index: 5;
 
-  .cart-items {
+  .items {
     height: 240px;
     display: flex;
     flex-direction: column;
-    overflow: scroll;
+    overflow-y: scroll;
   }
 
   button {

--- a/src/components/CartIcon/CartIcon.jsx
+++ b/src/components/CartIcon/CartIcon.jsx
@@ -1,22 +1,27 @@
 import React from "react";
 import { connect } from "react-redux";
 import { toggleCartHidden } from "../../redux/cart/actions";
+import { selectCartItemsCount } from "../../redux/cart/selectors";
 
 import { ReactComponent as ShoppingIcon } from "../../assets/shopping-bag.svg";
 
 import "./CartIcon.scss";
 
-const CartIcon = ({ toggleCartHidden }) => {
+const CartIcon = ({ itemCount, toggleCartHidden }) => {
   return (
     <div className="CartIcon" onClick={toggleCartHidden}>
       <ShoppingIcon className="shopping-icon" />
-      <span className="item-count">0</span>
+      <span className="item-count">{itemCount}</span>
     </div>
   );
 };
+
+const mapStateToProps = (state) => ({
+  itemCount: selectCartItemsCount(state),
+});
 
 const mapDispatchToProps = (dispatch) => ({
   toggleCartHidden: () => dispatch(toggleCartHidden()),
 });
 
-export default connect(null, mapDispatchToProps)(CartIcon);
+export default connect(mapStateToProps, mapDispatchToProps)(CartIcon);

--- a/src/components/CartItem/CartItem.jsx
+++ b/src/components/CartItem/CartItem.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import "./CartItem.scss";
+
+const CartItem = ({ item: { imageUrl, price, name, quantity } }) => {
+  return (
+    <div className="CartItem">
+      <img src={imageUrl} alt="item" />
+      <div className="details">
+        <span className="name">{name}</span>
+        <span className="price">
+          {quantity} x ${price}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default CartItem;

--- a/src/components/CartItem/CartItem.scss
+++ b/src/components/CartItem/CartItem.scss
@@ -1,0 +1,23 @@
+.CartItem {
+  width: 100%;
+  display: flex;
+  height: 80px;
+  margin-bottom: 15px;
+
+  img {
+    width: 30%;
+  }
+
+  .details {
+    width: 70%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 10px 20px;
+
+    .name {
+      font-size: 16px;
+    }
+  }
+}

--- a/src/redux/cart/selectors.js
+++ b/src/redux/cart/selectors.js
@@ -1,0 +1,17 @@
+import { createSelector } from "reselect";
+
+const selectCart = (state) => state.cart;
+
+export const selectCartItems = createSelector(
+  [selectCart],
+  (cart) => cart.cartItems
+);
+
+export const selectCartItemsCount = createSelector(
+  [selectCartItems],
+  (cartItems) =>
+    cartItems.reduce(
+      (accumulatedQty, cartItem) => accumulatedQty + cartItem.quantity,
+      0
+    )
+);


### PR DESCRIPTION
- As any 'Add to Cart' button is pressed, a corresponding `CartItem` component is added in the `CartDropdown`
-  Included the package `reselect`, which memoizes selectors (function which take only slices of the entire app state) [to save the extra computation when values don't change](https://www.npmjs.com/package/reselect#motivation-for-memoized-selectors).