### PR TITLE
Lazy loading of Routes | Code Splitting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,21 @@
-import React, { useEffect } from "react";
+import React, { useEffect, lazy, Suspense } from "react";
 import { Route, Switch, Redirect } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 
 import Header from "./components/Header";
-import HomePage from "./pages/HomePage";
-import ShopPage from "./pages/ShopPage";
-import SignInAndSignOutPage from "./pages/SignInAndSignOutPage";
-import CheckoutPage from "./pages/CheckoutPage";
+import Spinner from "./components/Loadable/Spinner";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 import { GlobalStyle } from "./global.styles";
 
 import { selectCurrentUser } from "./redux/user/selectors";
 import { checkUserSession } from "./redux/user/actions";
+
+const HomePage = lazy(() => import("./pages/HomePage"));
+const ShopPage = lazy(() => import("./pages/ShopPage"));
+const SignInAndSignOutPage = lazy(() => import("./pages/SignInAndSignOutPage"));
+const CheckoutPage = lazy(() => import("./pages/CheckoutPage"));
+
 
 function App() {
   const currentUser = useSelector((state) => selectCurrentUser(state));
@@ -27,16 +31,20 @@ function App() {
       <Header />
       <div className="page-content">
         <Switch>
-          <Route exact path="/" component={HomePage} />
-          <Route path="/shop" component={ShopPage} />
-          <Route exact path="/checkout" component={CheckoutPage} />
-          <Route
-            exact
-            path="/signin"
-            render={() =>
-              currentUser ? <Redirect to="/" /> : <SignInAndSignOutPage />
-            }
-          />
+          <ErrorBoundary>
+            <Suspense fallback={<Spinner />}>
+              <Route exact path="/" component={HomePage} />
+              <Route path="/shop" component={ShopPage} />
+              <Route exact path="/checkout" component={CheckoutPage} />
+              <Route
+                exact
+                path="/signin"
+                render={() =>
+                  currentUser ? <Redirect to="/" /> : <SignInAndSignOutPage />
+                }
+              />
+            </Suspense>
+          </ErrorBoundary>
         </Switch>
       </div>
     </div>

--- a/src/components/ErrorBoundary/error-boundary-styles.js
+++ b/src/components/ErrorBoundary/error-boundary-styles.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const ErrorImageOverlay = styled.div`
+  height: 60vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ErrorImageContainer = styled.div`
+  display: inline-block;
+  background-image: ${({ imageUrl }) => `url(${imageUrl})`};
+  background-size: cover;
+  background-position: center;
+  width: 40vh;
+  height: 40vh;
+`;
+
+export const ErrorImageText = styled.h2`
+  font-size: 28px;
+  color: #2f8e89;
+`;

--- a/src/components/ErrorBoundary/index.jsx
+++ b/src/components/ErrorBoundary/index.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+
+import { ErrorImageContainer, ErrorImageOverlay, ErrorImageText } from "./error-boundary-styles"
+
+export default class ErrorBoundary extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(error) {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        console.log(error, errorInfo);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return <ErrorImageOverlay>
+                <ErrorImageContainer imageUrl="https://i.imgur.com/yW2W9SC.png" />
+                <ErrorImageText>
+                    Sorry this page is broken
+                </ErrorImageText>
+            </ErrorImageOverlay>;
+        }
+
+        return this.props.children;
+    }
+}

--- a/src/components/ErrorBoundary/index.jsx
+++ b/src/components/ErrorBoundary/index.jsx
@@ -1,31 +1,37 @@
 import React, { Component } from "react";
 
-import { ErrorImageContainer, ErrorImageOverlay, ErrorImageText } from "./error-boundary-styles"
+import {
+  ErrorImageContainer,
+  ErrorImageOverlay,
+  ErrorImageText,
+} from "./error-boundary-styles";
 
 export default class ErrorBoundary extends Component {
-    constructor(props) {
-        super(props);
-        this.state = { hasError: false };
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.log(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorImageOverlay>
+          <ErrorImageContainer imageUrl="https://i.imgur.com/yW2W9SC.png" />
+          <ErrorImageText>
+            Sorry this page is unvailable at the moment
+          </ErrorImageText>
+        </ErrorImageOverlay>
+      );
     }
 
-    static getDerivedStateFromError(error) {
-        return { hasError: true };
-    }
-
-    componentDidCatch(error, errorInfo) {
-        console.log(error, errorInfo);
-    }
-
-    render() {
-        if (this.state.hasError) {
-            return <ErrorImageOverlay>
-                <ErrorImageContainer imageUrl="https://i.imgur.com/yW2W9SC.png" />
-                <ErrorImageText>
-                    Sorry this page is broken
-                </ErrorImageText>
-            </ErrorImageOverlay>;
-        }
-
-        return this.props.children;
-    }
+    return this.props.children;
+  }
 }

--- a/src/pages/ShopPage/index.jsx
+++ b/src/pages/ShopPage/index.jsx
@@ -1,11 +1,14 @@
-import React, { useEffect } from "react";
+import React, { lazy, Suspense, useEffect } from "react";
 import { Route, useRouteMatch } from "react-router-dom";
 import { useDispatch } from "react-redux";
 
 import { fetchCollectionsStart } from "../../redux/shop/actions";
 
-import CollectionsOverview from "../../components/CollectionsOverview";
-import CollectionPage from "../CollectionPage";
+import Spinner from "../../components/Loadable/Spinner";
+import ErrorBoundary from "../../components/ErrorBoundary";
+
+const CollectionsOverview = lazy(() => import("../../components/CollectionsOverview"));
+const CollectionPage = lazy(() => import("../CollectionPage"));
 
 function ShopPage() {
   const match = useRouteMatch();
@@ -17,8 +20,12 @@ function ShopPage() {
 
   return (
     <div className="ShopPage">
-      <Route exact path={`${match.path}`} component={CollectionsOverview} />
-      <Route path={`${match.path}/:collectionId`} component={CollectionPage} />
+      <ErrorBoundary>
+        <Suspense fallback={<Spinner />}>
+          <Route exact path={`${match.path}`} component={CollectionsOverview} />
+          <Route path={`${match.path}/:collectionId`} component={CollectionPage} />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/redux/shop/selectors.js
+++ b/src/redux/shop/selectors.js
@@ -11,7 +11,9 @@ export const selectShopCollections = createSelector(
 export const selectShopCollectionsForPreview = createSelector(
   [selectShopCollections],
   (collections) =>
-    collections ? Object.keys(collections).map((key) => collections[key]) : []
+    collections && Object.keys(collections).length > 0
+      ? Object.keys(collections).map((key) => collections[key])
+      : {}
 );
 
 export const seclectCollection = memoize((collectionUrlParam) =>


### PR DESCRIPTION
- Every react-router-dom Route defined in th app are now lazy-loaded, meaning that they earch get their own chunk , which gets loaded separately at run time.  This is done through [code splitting](https://reactjs.org/docs/code-splitting.html).
- So for example, once the homepage is loaded, once the user clicks on the the `shop` link found in the header, the corresponding chunk, containing the JS code for it, is loaded at that point only.  
- Because the routes are being loaded through `Suspense`, a spinner displays while the route component loads.
- Because the Suspense component is wrapped in an [ErrorBoundary](https://reactjs.org/docs/error-boundaries.html) component, loading errors are handle gracefully.